### PR TITLE
Do not return within a yield block

### DIFF
--- a/app/controllers/devise_castle/passwords_controller.rb
+++ b/app/controllers/devise_castle/passwords_controller.rb
@@ -9,17 +9,17 @@ class DeviseCastle::PasswordsController < Devise::PasswordsController
     end
 
     super do |resource|
-      return if resource.respond_to?(:castle_do_not_track?) && resource.castle_do_not_track?
-
-      begin
-        castle.track(
-          name: '$password_reset.requested',
-          details: {
-            '$login' => username
-          })
-      rescue ::Castle::Error => e
-        if Devise.castle_error_handler.is_a?(Proc)
-          Devise.castle_error_handler.call(e)
+      unless resource.respond_to?(:castle_do_not_track?) && resource.castle_do_not_track?
+        begin
+          castle.track(
+            name: '$password_reset.requested',
+            details: {
+              '$login' => username
+            })
+        rescue ::Castle::Error => e
+          if Devise.castle_error_handler.is_a?(Proc)
+            Devise.castle_error_handler.call(e)
+          end
         end
       end
     end
@@ -27,21 +27,21 @@ class DeviseCastle::PasswordsController < Devise::PasswordsController
 
   def update
     super do |resource|
-      return if resource.respond_to?(:castle_do_not_track?) && resource.castle_do_not_track?
-
-      begin
-        if resource.errors.empty?
-          castle.track(
-            name: '$password_reset.succeeded',
-            user_id: resource._castle_id)
-        else
-          castle.track(
-            name: '$password_reset.failed',
-            user_id: resource._castle_id)
-        end
-      rescue ::Castle::Error => e
-        if Devise.castle_error_handler.is_a?(Proc)
-          Devise.castle_error_handler.call(e)
+      unless resource.respond_to?(:castle_do_not_track?) && resource.castle_do_not_track?
+        begin
+          if resource.errors.empty?
+            castle.track(
+              name: '$password_reset.succeeded',
+              user_id: resource._castle_id)
+          else
+            castle.track(
+              name: '$password_reset.failed',
+              user_id: resource._castle_id)
+          end
+        rescue ::Castle::Error => e
+          if Devise.castle_error_handler.is_a?(Proc)
+            Devise.castle_error_handler.call(e)
+          end
         end
       end
     end


### PR DESCRIPTION
passwords_controller should use unless instead of return for castle_do_not_track logic (likes hooks.rb does).  Otherwise, the code after the yield does not get run (http://railsware.com/blog/2012/11/20/yield-gotcha-in-ruby-blocks/) which means that instead of redirecting after changing the password, it shows an error message saying that there is no password update controller.